### PR TITLE
Linked brushing display using detourr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,9 @@ Imports:
     Rtsne,
     uwot,
     lle,
-    magrittr
+    magrittr,
+    detourr,
+    crosstalk
 RoxygenNote: 7.1.1
 Suggests: 
     knitr,

--- a/R/server.R
+++ b/R/server.R
@@ -407,6 +407,27 @@ pandemonium <- function(pred, covInv, wc, exp, user_coord = NULL, user_dist = NU
     }
     )
 
+    shiny::observeEvent(rv$groups,{
+      detour_data <- as.data.frame(pred)
+      detour_data$colour <- rv$groups
+      rv$shared_detour <- crosstalk::SharedData$new(detour_data)
+      rv$depal <- if (length(unique(rv$groups)) == 2) rv$pal[-3] else rv$pal
+    })
+    
+    output$detour1   <- detourr::shinyRenderDisplayScatter2d(detourr::detour(rv$shared_detour, 
+                                                                             detourr::tour_aes(projection = colnames(pred),colour = colour)) |>
+                                                               detourr::tour_path(detourr::grand_tour(2), fps = 60, 
+                                                                                  max_bases=20) |>
+                                                               detourr::show_scatter(alpha = 0.7, 
+                                                                                     axes = TRUE, scale_factor = 0.4, palette = rv$depal), quoted = FALSE)
+    output$detour2 <- detourr::shinyRenderDisplayScatter2d(detourr::detour(rv$shared_detour, 
+                                                                           detourr::tour_aes(projection = colnames(pred),colour = colour)) |>
+                                                             detourr::tour_path(detourr::local_tour(tourr::basis_random(n=ncol(pred))), fps = 60, 
+                                                                                max_bases=20) |>
+                                                             detourr::show_scatter(alpha = 0.7, 
+                                                                                   axes = TRUE, scale_factor = 0.4, palette = rv$depal), quoted = FALSE)
+    
+
   }
 
   shiny::shinyApp(ui(colnames(wc)), server)

--- a/R/ui.R
+++ b/R/ui.R
@@ -150,5 +150,12 @@ ui <- function(params){
                         shiny::plotOutput("wcB")))
                     ))),
   shiny::tabPanel("Statistics",
-                  shiny::fluidPage(shiny::plotOutput("clusterstats")))
+                  shiny::fluidPage(shiny::plotOutput("clusterstats"))),
+  shiny::tabPanel("Detourr",
+                  shiny::fluidPage(
+                      shiny::fluidRow(shiny::column(6,
+                                                  detourr::displayScatter2dOutput("detour1",width = "100%", height = "400px")),          
+                                      shiny::column(6,
+                                                  detourr::displayScatter2dOutput("detour2",width = "100%", height = "400px")))
+                      ))
 ))}


### PR DESCRIPTION
linked brushing has been added to give further insights into the cluster analysis.

 `ui.R` a new tab panel has been added with interactive `detourr` displays.

`server.R` a new event has been added to create `rv$shared_detour` a `crosstalk` shared data variable of `pred`. Two outputs of the detourr displays are also created.

<img width="902" alt="Screen Shot 2025-03-24 at 12 08 12 am" src="https://github.com/user-attachments/assets/038c741b-353a-4a86-be0e-4bdc13688b2a" />
